### PR TITLE
Adds character counting, shortest post stats, more longest post information, draft post exclusion, etc

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,17 +16,17 @@ For published & draft posts `{% posts_word_count PARAM %}`
 
 Where `PARAM` is one of:
 
-*	`total` (total word count of all posts)
-*	`average` (average word count across all posts)
+* `total` (total word count of all posts)
+* `average` (average word count across all posts)
 * `total_characters` (total character count of all posts)
 * `average_characters` (total average count of all posts)
-*	`longest` (longest word count of any post)
-*	`longest_post_index` (index in site.posts of longest post)
-*	`longest_post_title` (title of longest post)
+* `longest` (longest word count of any post)
+* `longest_post_index` (index in site.posts of longest post)
+* `longest_post_title` (title of longest post)
 * `longest_post_url` (url of longest post)
-*	`shortest` (shortest word count of any post)
-*	`shortest_post_index` (index in site.posts of shortest post)
-*	`shortest_post_title` (title of shortest post)
+* `shortest` (shortest word count of any post)
+* `shortest_post_index` (index in site.posts of shortest post)
+* `shortest_post_title` (title of shortest post)
 * `shortest_post_url` (url of shortest post)
 
 ## Example

--- a/README.markdown
+++ b/README.markdown
@@ -18,16 +18,16 @@ Where `PARAM` is one of:
 
 *	`total` (total word count of all posts)
 *	`average` (average word count across all posts)
-*   `total_characters` (total character count of all posts)
-*   `average_characters` (total average count of all posts)
+* `total_characters` (total character count of all posts)
+* `average_characters` (total average count of all posts)
 *	`longest` (longest word count of any post)
 *	`longest_post_index` (index in site.posts of longest post)
 *	`longest_post_title` (title of longest post)
-*   `longest_post_url` (url of longest post)
+* `longest_post_url` (url of longest post)
 *	`shortest` (shortest word count of any post)
 *	`shortest_post_index` (index in site.posts of shortest post)
 *	`shortest_post_title` (title of shortest post)
-*   `shortest_post_url` (url of shortest post)
+* `shortest_post_url` (url of shortest post)
 
 ## Example
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,30 +1,48 @@
-#Jekyll-Posts-Word-Count
+# Jekyll-Posts-Word-Count
 
-by Matt Gemmell - [mattgemmell.com](http://mattgemmell.com) - [@mattgemmell](http://twitter.com/mattgemmell)
+[Jekyll](http://jekyllrb.com) plugin to give you the total / average word count, as well as shortest & longest post information across all posts.
 
-License: [CC0 Universal (public domain)](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
+*By [Matt Gemmell](https://mattgemmell.com) / [Jake Lee](https://jakelee.co.uk), license: [CC0 Universal (public domain)](https://creativecommons.org/publicdomain/zero/1.0/deed.en)*
 
-* * *
-
-##Description
-
-[Jekyll](http://jekyllrb.com) plugin to give you the total, average, and longest word-count across all your posts.
-
-
-##Installation
+## Installation
 
 To install, copy the `posts-word-count.rb` file into your Jekyll `_plugins` folder.
 
+## Usage
 
-##Usage
+For only published posts: `{% posts_word_count PARAM %}`
 
-    {% posts_word_count PARAM %}
+For published & draft posts `{% posts_word_count PARAM %}`
 
-`PARAM` can be:
+Where `PARAM` is one of:
 
-* `total` (total word count of all posts)
-* `average` (average word count across all posts)
-* `longest` (longest word count of any post)
-* `longest_post_index` (index in `site.posts` of longest post, assuming reverse chronological order)
+*	`total` (total word count of all posts)
+*	`average` (average word count across all posts)
+*   `total_characters` (total character count of all posts)
+*   `average_characters` (total average count of all posts)
+*	`longest` (longest word count of any post)
+*	`longest_post_index` (index in site.posts of longest post)
+*	`longest_post_title` (title of longest post)
+*   `longest_post_url` (url of longest post)
+*	`shortest` (shortest word count of any post)
+*	`shortest_post_index` (index in site.posts of shortest post)
+*	`shortest_post_title` (title of shortest post)
+*   `shortest_post_url` (url of shortest post)
 
-In each case, the return value is a string containing a number.
+## Example
+
+For example, a page displaying overall stats and the shortest & longest posts could include:
+
+```
+### Totals
+
+Total site words: {% posts_word_count total %} (average {% posts_word_count average %} per post)
+
+Total site characters: {% posts_word_count total_characters %} (average {% posts_word_count average_characters %} per post)
+
+### Published post records 
+
+Longest post: <a href="{% published_posts_word_count longest_post_url %}">{% published_posts_word_count longest_post_title %}</a> ({% published_posts_word_count longest %} words)
+
+Shortest post: <a href="{% published_posts_word_count shortest_post_url %}">{% published_posts_word_count shortest_post_title %}</a> ({% published_posts_word_count shortest %} words)
+```

--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ To install, copy the `posts-word-count.rb` file into your Jekyll `_plugins` fold
 
 ## Usage
 
-For only published posts: `{% posts_word_count PARAM %}`
+For only published posts: `{% published_posts_word_count PARAM %}`
 
 For published & draft posts `{% posts_word_count PARAM %}`
 

--- a/posts-word-count.rb
+++ b/posts-word-count.rb
@@ -8,16 +8,16 @@
 # PARAM can be:
 #	total (total word count of all posts)
 #	average (average word count across all posts)
-#   total_characters (total character count of all posts)
-#   average_characters (total average count of all posts)
+#	total_characters (total character count of all posts)
+#	average_characters (total average count of all posts)
 #	longest (longest word count of any post)
 #	longest_post_index (index in site.posts of longest post)
 #	longest_post_title (title of longest post)
-#   longest_post_url (url of longest post)
+#	longest_post_url (url of longest post)
 #	shortest (shortest word count of any post)
 #	shortest_post_index (index in site.posts of shortest post)
 #	shortest_post_title (title of shortest post)
-#   shortest_post_url (url of shortest post)
+#	shortest_post_url (url of shortest post)
 
 class PostsWordCount < Liquid::Tag
 	def initialize(tag, text, tokens)

--- a/posts-word-count.rb
+++ b/posts-word-count.rb
@@ -7,9 +7,14 @@
 # PARAM can be:
 #	total (total word count of all posts)
 #	average (average word count across all posts)
+#   total_characters (total character count of all posts)
+#   average_characters (total average count of all posts)
 #	longest (longest word count of any post)
 #	longest_post_index (index in site.posts of longest post)
 #	longest_post_title (title of longest post)
+#	shortest (shortest word count of any post)
+#	shortest_post_index (index in site.posts of shortest post)
+#	shortest_post_title (title of shortest post)
 
 class PostsWordCount < Liquid::Tag
 	def initialize(tag, text, tokens)
@@ -19,6 +24,8 @@ class PostsWordCount < Liquid::Tag
 		@average_character_count = 0
 		@longest_word_count = 0
 		@longest_post_index = 0
+		@shortest_word_count = 0
+		@shortest_post_index = 0
 		@tag = tag
 		@text = text.strip
 		@tokens = tokens
@@ -39,6 +46,12 @@ class PostsWordCount < Liquid::Tag
 				@longest_post_index = all_posts.count - (index + 1)
 				@longest_post_title = all_posts[index].data["title"]
 			end
+
+			if num_words < @shortest_word_count || @shortest_word_count == 0
+				@shortest_word_count = num_words
+				@shortest_post_index = all_posts.count - (index + 1)
+				@shortest_post_title = all_posts[index].data["title"]
+			end
 		}
 		@average_word_count = @total_word_count / all_posts.count
 		@average_character_count = @total_character_count / all_posts.count
@@ -57,6 +70,12 @@ class PostsWordCount < Liquid::Tag
 			the_result = @longest_post_title
 		elsif @text == "longest"
 			the_result = @longest_word_count
+		elsif @text == "shortest_post_index"
+			the_result = @shortest_post_index
+		elsif @text == "shortest_post_title"
+			the_result = @shortest_post_title
+		elsif @text == "shortest"
+			the_result = @shortest_word_count
 		end
 
 		return the_result

--- a/posts-word-count.rb
+++ b/posts-word-count.rb
@@ -9,11 +9,14 @@
 #	average (average word count across all posts)
 #	longest (longest word count of any post)
 #	longest_post_index (index in site.posts of longest post)
+#	longest_post_title (title of longest post)
 
 class PostsWordCount < Liquid::Tag
 	def initialize(tag, text, tokens)
 		@total_word_count = 0
 		@average_word_count = 0
+		@total_character_count = 0
+		@average_character_count = 0
 		@longest_word_count = 0
 		@longest_post_index = 0
 		@tag = tag
@@ -27,6 +30,10 @@ class PostsWordCount < Liquid::Tag
 		all_posts.each_with_index { |this_post, index|
 			num_words = word_count(this_post.content)
 			@total_word_count += num_words
+
+			num_chars = this_post.content.length
+			@total_character_count += num_chars
+
 			if num_words > @longest_word_count
 				@longest_word_count = num_words
 				@longest_post_index = all_posts.count - (index + 1)
@@ -34,16 +41,21 @@ class PostsWordCount < Liquid::Tag
 			end
 		}
 		@average_word_count = @total_word_count / all_posts.count
+		@average_character_count = @total_character_count / all_posts.count
 
-		if @text.start_with? "total"
+		if @text == "total"
 			the_result = @total_word_count
-		elsif @text.start_with? "average"
+		elsif @text == "average"
 			the_result = @average_word_count
-		elsif @text.start_with? "longest_post_index"
+		elsif @text == "total_characters"
+			the_result = @total_character_count
+		elsif @text == "average_characters"
+			the_result = @average_character_count
+		elsif @text == "longest_post_index"
 			the_result = @longest_post_index
-		elsif @text.start_with? "longest_post_title"
+		elsif @text == "longest_post_title"
 			the_result = @longest_post_title
-		elsif @text.start_with? "longest"
+		elsif @text == "longest"
 			the_result = @longest_word_count
 		end
 

--- a/posts-word-count.rb
+++ b/posts-word-count.rb
@@ -2,7 +2,8 @@
 # Output some interesting word-count stats for your posts.
 #
 # To install, copy this file into your Jekyll/Octopress plugins folder
-# To use: {% posts_word_count PARAM %}
+# To use: {% posts_word_count PARAM %} for all posts,
+# or: {% published_posts_word_count PARAM %} for only non-draft posts.
 #
 # PARAM can be:
 #	total (total word count of all posts)
@@ -12,9 +13,11 @@
 #	longest (longest word count of any post)
 #	longest_post_index (index in site.posts of longest post)
 #	longest_post_title (title of longest post)
+#   longest_post_url (url of longest post)
 #	shortest (shortest word count of any post)
 #	shortest_post_index (index in site.posts of shortest post)
 #	shortest_post_title (title of shortest post)
+#   shortest_post_url (url of shortest post)
 
 class PostsWordCount < Liquid::Tag
 	def initialize(tag, text, tokens)
@@ -35,6 +38,8 @@ class PostsWordCount < Liquid::Tag
 		the_result = nil
 		all_posts = context.registers[:site].posts.docs # OLDEST first!
 		all_posts.each_with_index { |this_post, index|
+			next if all_posts[index].data["draft"] && @tag == "published_posts_word_count"
+
 			num_words = word_count(this_post.content)
 			@total_word_count += num_words
 
@@ -45,12 +50,14 @@ class PostsWordCount < Liquid::Tag
 				@longest_word_count = num_words
 				@longest_post_index = all_posts.count - (index + 1)
 				@longest_post_title = all_posts[index].data["title"]
+				@longest_post_url = this_post.url
 			end
 
 			if num_words < @shortest_word_count || @shortest_word_count == 0
 				@shortest_word_count = num_words
 				@shortest_post_index = all_posts.count - (index + 1)
 				@shortest_post_title = all_posts[index].data["title"]
+				@shortest_post_url = this_post.url
 			end
 		}
 		@average_word_count = @total_word_count / all_posts.count
@@ -64,18 +71,22 @@ class PostsWordCount < Liquid::Tag
 			the_result = @total_character_count
 		elsif @text == "average_characters"
 			the_result = @average_character_count
+		elsif @text == "longest"
+			the_result = @longest_word_count
 		elsif @text == "longest_post_index"
 			the_result = @longest_post_index
 		elsif @text == "longest_post_title"
 			the_result = @longest_post_title
-		elsif @text == "longest"
-			the_result = @longest_word_count
+		elsif @text == "longest_post_url"
+			the_result = @longest_post_url
+		elsif @text == "shortest"
+			the_result = @shortest_word_count
 		elsif @text == "shortest_post_index"
 			the_result = @shortest_post_index
 		elsif @text == "shortest_post_title"
 			the_result = @shortest_post_title
-		elsif @text == "shortest"
-			the_result = @shortest_word_count
+		elsif @text == "shortest_post_url"
+			the_result = @shortest_post_url
 		end
 
 		return the_result
@@ -88,3 +99,4 @@ class PostsWordCount < Liquid::Tag
 end
 
 Liquid::Template.register_tag('posts_word_count', PostsWordCount)
+Liquid::Template.register_tag('published_posts_word_count', PostsWordCount)


### PR DESCRIPTION
Hey!

Great plugin, super readable code

Added a ton of stuff to the plugin as I needed it:
* `published_posts_word_count` to exclude draft posts.
* Longest post title & URL
* Shortest post
* Character count
* Fixed readme

All changes are fully backwards compatible.

Also added my own name to the readme, hopefully that's not too presumptuous! 